### PR TITLE
Full Extraction - All Pages results

### DIFF
--- a/candore/candore.py
+++ b/candore/candore.py
@@ -16,36 +16,26 @@ def list_endpoints():
     return api_lister.lister_endpoints()
 
 
-async def save_all_entities(mode, api_lister=api_lister):
+async def save_all_entities(mode, output_file, full):
     """Save all the entities to a json file
 
     :param mode: Pre or Post
-    :param api_lister: The candore.modules.api_lister.APILister object
+    :param output_file: Output file name
+    :param full: If True, save entities from all pages of the components, else just saves first page
     :return: None
     """
     if mode not in ['pre', 'post']:
         raise ModeError("Extracting mode must be 'pre' or 'post'")
 
     async with Extractor(apilister=api_lister) as extractor:
+        if full:
+            extractor.full = True
         data = await extractor.extract_all_entities()
 
     if not data:
         click.echo('Entities data is not data found!')
 
-    file_path = Path(f'{mode}_entities.json')
-    with file_path.open(mode='w') as entfile:
-        json.dump(data, entfile)
-    click.echo(f'Entities data saved to {file_path}')
-    if mode not in ['pre', 'post']:
-        raise ModeError("Extracting mode must be 'pre' or 'post'")
-
-    async with Extractor(apilister=api_lister) as extractor:
-        data = await extractor.extract_all_entities()
-
-    if not data:
-        click.echo('Entities data is not data found!')
-
-    file_path = Path(f'{mode}_entities2.json')
+    file_path = Path(output_file) if output_file else Path(f'{mode}_entities.json')
     with file_path.open(mode='w') as entfile:
         json.dump(data, entfile)
     click.echo(f'Entities data saved to {file_path}')

--- a/candore/cli.py
+++ b/candore/cli.py
@@ -32,10 +32,12 @@ def apis(ctx):
 
 @candore.command(help="Extract and save data using API lister endpoints")
 @click.option("--mode", type=str, help="The mode must be 'pre' or 'post'")
+@click.option("-o", "--output", type=str, help="The output file name")
+@click.option("--full", is_flag=True, help="Extract data from all the pages of a component")
 @click.pass_context
-def extract(ctx, mode):
+def extract(ctx, mode, output, full):
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(save_all_entities(mode=mode))
+    loop.run_until_complete(save_all_entities(mode=mode, output_file=output, full=full))
 
 
 @candore.command(help="Compare pre and post upgrade data")


### PR DESCRIPTION
Currently, candore by default is not extracting results from all pages, it just picks from the first page. 

TBH it's not necessary to retrieve all of them for comparision because sample data from one page to identify the variation itself is good enough.

But still any individual needs to due to a full extraction for comparision, then this PR adds the support for full extraction using `--full` option with `candore extract` command.

e.g:

```
candore extract --mode pre --full
```

Also, this PR enables an option to mention the path for json data file using `-o` or `--output`.
e.g:
```
candore extract -o pretests.json --mode pre
```