### PR TITLE
Expected and Skipped Variations

### DIFF
--- a/candore/candore.py
+++ b/candore/candore.py
@@ -41,8 +41,10 @@ async def save_all_entities(mode, output_file, full):
     click.echo(f'Entities data saved to {file_path}')
 
 
-def compare_entities(pre_file=None, post_file=None, output=None, report_type=None):
+def compare_entities(pre_file=None, post_file=None, output=None, report_type=None, record_evs=None):
     comp = Comparator()
+    if record_evs:
+        comp.record_evs = True
     results = comp.compare_json(pre_file=pre_file, post_file=post_file)
     reporter = Reporting(results=results)
     reporter.generate_report(output_file=output, output_type=report_type)

--- a/candore/cli.py
+++ b/candore/cli.py
@@ -45,9 +45,10 @@ def extract(ctx, mode, output, full):
 @click.option("--post", type=str, help="The post upgrade json file")
 @click.option("-o", "--output", type=str, help="The output file name")
 @click.option("-t", "--report-type", type=str, default='json', help="The type of report GSheet, JSON, or webpage")
+@click.option("--record-evs", is_flag=True, help="Record Expected Variations in reporting")
 @click.pass_context
-def compare(ctx, pre, post, output, report_type):
-    compare_entities(pre_file=pre, post_file=post, output=output, report_type=report_type)
+def compare(ctx, pre, post, output, report_type, record_evs):
+    compare_entities(pre_file=pre, post_file=post, output=output, report_type=report_type, record_evs=record_evs)
 
 
 if __name__ == "__main__":

--- a/candore/config.py
+++ b/candore/config.py
@@ -23,7 +23,6 @@ def validate_settings():
     settings.validators.register(Validator(*provider_settings, ne=None))
     try:
         settings.validators.validate()
-        print(f"The settings are initialized and validated !")
     except Exception as ecc:
         raise ecc
 

--- a/candore/modules/report.py
+++ b/candore/modules/report.py
@@ -77,9 +77,9 @@ class Reporting:
         output_file = Path(output_file)
         # Convert json to csv and write to output file
         csv_writer = csv.writer(output_file.open('w'))
-        csv_writer.writerow(['Variation Path', 'Pre-Upgrade', 'Post-Upgrade'])
+        csv_writer.writerow(['Variation Path', 'Pre-Upgrade', 'Post-Upgrade', 'Variation'])
         for var_path, vals in self.results.items():
-            csv_writer.writerow([var_path, vals['pre'], vals['post']])
+            csv_writer.writerow([var_path, vals['pre'], vals['post'], vals['variation']])
         print("Wrote CSV report to {}".format(output_file))
         print("CSV report contains {} results".format(len(self.results)))
 

--- a/conf/variations/6_14.yaml
+++ b/conf/variations/6_14.yaml
@@ -1,0 +1,10 @@
+expected_variations: []
+#  hosts:
+#    - realm_id
+#    - capabilities
+#  smart_proxies:
+#    features: name
+
+skipped_variations: []
+#  hosts:
+#    reported_data: boot_time

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,8 +1,9 @@
 candore:
-  base_url: http://ip-10-0-167-207.rhos-01.prod.psi.rdu2.redhat.com
-  username: admin
-  password: changeme
+  base_url:
+  username:
+  password:
   product_name: satellite
   version: 6.14
   docpath: /apidoc
   parser: apipie
+  var_file: "@jinja conf/variations/{{this.candore.version | replace('.', '_')}}.yaml"

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -2,7 +2,8 @@ candore:
   base_url:
   username:
   password:
-  product_name:
-  version:
+  product_name: satellite
+  version: 6.14
   docpath: /apidoc
   parser: apipie
+  var_file: "@jinja conf/variations/{{this.candore.version | replace('.', '_')}}.yaml"


### PR DESCRIPTION
Added the Expected Variations and Skipped Variations functionalities to candore that :
- Either hide the expected/skipped variations from the report or Shows as `Expected` in the report
- An option `--record-evs` will show them in the report if mentioned else it won't
- New `conf/variations.yaml` file to mention expected/skipped variations path

Also,
- Now Keys missing in post upgrade would be recorded in report (vs STDOUT print early) with variation column showing `Post Key missing` 