### PR TITLE
Handle case where no data is returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ settings.yaml
 *.csv
 .idea
 trust
+venv*

--- a/candore/modules/extractor.py
+++ b/candore/modules/extractor.py
@@ -76,6 +76,8 @@ class Extractor:
                     # like services, api etc
                     # which does not have results
                     return entity_data
+            else:
+                return entity_data
         # If the entity has multiple pages, fetch them all
         if self.full:
             total_pages = results.get("total") // results.get("per_page") + 1


### PR DESCRIPTION
In cases where there was not data returned, the method should exit and pass along the default. Otherwise, it will continue on with an undefined results object.