### PR TITLE
Finder/Reader to read the specific path from json file

### DIFF
--- a/candore/__init__.py
+++ b/candore/__init__.py
@@ -1,6 +1,7 @@
 import asyncio  # noqa: F401
 import json
 from pathlib import Path
+from pprint import pprint
 
 import click
 
@@ -8,6 +9,7 @@ from candore.errors import ModeError
 from candore.modules.api_lister import APILister
 from candore.modules.comparator import Comparator
 from candore.modules.extractor import Extractor
+from candore.modules.finder import Finder
 from candore.modules.report import Reporting
 
 
@@ -58,3 +60,9 @@ class Candore:
         results = comp.compare_json(pre_file=pre_file, post_file=post_file)
         reporter = Reporting(results=results)
         reporter.generate_report(output_file=output, output_type=report_type)
+
+    def find_path(self, path, json_file, delimiter):
+        finder = Finder()
+        data = finder.find(path=path, json_file=json_file, delimiter=delimiter)
+        if data:
+            pprint(data)

--- a/candore/cli.py
+++ b/candore/cli.py
@@ -75,5 +75,23 @@ def compare(ctx, pre, post, output, report_type, record_evs):
     )
 
 
+@candore.command(help="JSON Reader for reading the specific path data from entities data file")
+@click.option(
+    "--path",
+    type=str,
+    help="The path to search the data from.\n"
+    "Path contents could divided by some delimiter.\n"
+    "e.g entity/5/description",
+)
+@click.option(
+    "--data-file", type=str, help="The data file from which to search the data on a given path"
+)
+@click.option("--delimiter", type=str, default='/', help="Settings file path. Default is '/'")
+@click.pass_context
+def reader(ctx, path, data_file, delimiter):
+    candore_obj = ctx.parent.candore
+    candore_obj.find_path(path=path, json_file=data_file, delimiter=delimiter)
+
+
 if __name__ == "__main__":
     candore()

--- a/candore/modules/finder.py
+++ b/candore/modules/finder.py
@@ -1,0 +1,41 @@
+import json
+
+
+class Finder:
+    def read_json(self, jsonfile=None):
+        jdata = None
+        with open(jsonfile) as file:
+            jdata = json.load(file)
+        return jdata
+
+    def json_iterator(self, data=None, path=None, delimiter=None):
+        if not data:
+            return data
+        if path:
+            path_contents = path.strip().split(delimiter)
+            first_path = path_contents[0]
+            remaining_path = f'{delimiter}'.join(path_contents[1:])
+
+            if isinstance(data, dict):
+                if first_path in data:
+                    return self.json_iterator(data.get(first_path, None), remaining_path, delimiter)
+                else:
+                    print(
+                        f'Oh!O! {first_path} is not found in given path, please correct the path!'
+                    )
+            elif isinstance(data, list):
+                for index, element_data in enumerate(data):
+                    if isinstance(element_data, dict):
+                        if 'id' in element_data and str(element_data['id']) == first_path:
+                            return self.json_iterator(element_data, remaining_path, delimiter)
+                    elif isinstance(element_data, list):
+                        if first_path in element_data:
+                            return self.json_iterator(
+                                element_data[index], remaining_path, delimiter
+                            )
+        else:
+            return data
+
+    def find(self, path=None, json_file=None, delimiter='/'):
+        jdata = self.read_json(json_file)
+        return self.json_iterator(jdata, path=path, delimiter=delimiter)


### PR DESCRIPTION
A reader / finder module to read a specific path from pre / post json files to get more details about the entity reported in comparision.

E.g hosts/9/reported_time is under the variation and one wants to what is the hostname of ID:9 and other details one can do that using this module.

On Terminal  `# candore reader --path hosts/9 --data-file pre_entities.json`


## Here is the example :

1.  If the variation is : 
```

Variation: content_view_versions/179/environments/39/publish_date   
PreUpgrade: 8 minutes
PostUpgrade: 29 minutes
```
and in this example if you want to know the details about environment of id: 39 

2. With pre-upgrade file u can do:
```
# candore reader --path content_view_versions/179/environments/39  --data-file pre_entities_6.14.json 
{'activation_key_count': 0,
 'host_count': 0,
 'id': 39,
 'label': 'Library',
 'name': 'Library',
 'permissions': {'all_hosts_editable': True,
                 'all_keys_editable': True,
                 'promotable_or_removable': True,
                 'readable': True},
 'publish_date': '8 minutes'}

```

3. With post-upgrade files u can do:
```
# candore reader --path content_view_versions/179/environments/39  --data-file post_entities_6.15.json 
{'activation_key_count': 0,
 'host_count': 0,
 'id': 39,
 'label': 'Library',
 'name': 'Library',
 'permissions': {'all_hosts_editable': True,
                 'all_keys_editable': True,
                 'promotable_or_removable': True,
                 'readable': True},
 'publish_date': '29 minutes'}
```

Now you can easily compare the pre and post data with more details on entity that has a variant!