### PR TITLE
Added async concurrency to extraction process

### DIFF
--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -8,3 +8,5 @@ candore:
   parser: apipie
   var_file: "@jinja {{this.candore.product_version | replace('.', '_')}}_variations.yaml"
   constant_File: "@jinja {{this.candore.product_version | replace('.', '_')}}_constants.yaml"
+  # The maximum number of concurrent (asynchronous) connections allowed against the host
+  max_connections: 20


### PR DESCRIPTION
This change speeds up the extraction process by allowing processing of paginated pages asynchronously up to a configurable concurrent limit.